### PR TITLE
Reference pull request for full details

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -44,7 +44,7 @@ function getScopeStr(configId: string) {
       `${cpatScopePrefix}c-pat:write`,
       `${cpatScopePrefix}c-pat:op`,
       'openid',
-      //'offline_access'
+      'offline_access'
     ];
   } else if (configId === 'stigman') {
     scopes = [

--- a/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.html
+++ b/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.html
@@ -13,7 +13,7 @@
     <ng-container *ngIf="notifications.length > 0; else noNotifications">
       <p-listbox [options]="notifications" optionLabel="title" scrollHeight="40vh">
         <ng-template let-notification pTemplate="item">
-          <div class="notification-content">
+          <div class="notification-content" (click)="onNotificationClick($event)">
             <div class="notification-header">
               <div class="notification-icon">
                 <i [class]="notification.icon"></i>
@@ -21,7 +21,7 @@
               <h5>{{ notification.title }}</h5>
               <i *ngIf="notification.notificationId" class="dismiss-icon pi pi-times" (click)="dismissNotification(notification)" (onKeyUp)="dismissNotification(notification)"></i>
             </div>
-            <p>{{ notification.message }}</p>
+            <p [innerHTML]="notification.formattedMessage"></p>
             <small>{{ notification.timestamp | date:'short' }}</small>
           </div>
         </ng-template>

--- a/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.scss
+++ b/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.scss
@@ -15,6 +15,16 @@
   flex-direction: column;
   margin-bottom: 0;
 
+  ::ng-deep .poam-link {
+    color: var(--primary-color);
+    font-weight: bold;
+    text-decoration: none;
+  }
+  
+  ::ng-deep .poam-link:hover {
+    text-decoration: underline;
+  }
+
   .header-actions {
     display: flex;
     justify-content: flex-end;
@@ -72,3 +82,4 @@
     text-align: center;
   }
 }
+

--- a/client/src/app/common/components/notifications/notifications.component.html
+++ b/client/src/app/common/components/notifications/notifications.component.html
@@ -17,17 +17,17 @@
                 placeholder="Filter by status..."
                 styleClass="mb-2 md:mb-0"></p-dropdown>
   </div>
-
   <div class="notifications-container">
     <p-dataView #dv [value]="filteredNotifications" [sortField]="sortField" [sortOrder]="sortOrder">
       <ng-template pTemplate="list" let-notifications>
         <div class="grid">
           <div class="col-12" *ngFor="let notification of notifications">
             <div class="flex flex-column md:flex-row align-items-center p-3 w-full"
-                 [ngClass]="{'surface-hover': notification.read, 'surface-100': !notification.read}">
+                 [ngClass]="{'surface-hover': notification.read, 'surface-100': !notification.read}"
+                 (click)="onNotificationClick($event)">
               <div class="flex-1">
                 <h4 class="mb-2">{{ notification.title }}</h4>
-                <p class="mt-0 mb-2 line-height-3">{{ notification.message }}</p>
+                <p class="mt-0 mb-2 line-height-3" [innerHTML]="notification.formattedMessage"></p>
                 <span class="flex align-items-center">
                   <i class="pi pi-clock mr-2"></i>
                   <small>{{ notification.timestamp | date:'short' }}</small>
@@ -51,7 +51,6 @@
       </ng-template>
     </p-dataView>
   </div>
-
   <div class="mt-3 flex justify-content-end">
     <p-button label="Mark all as read"
               icon="pi pi-check"

--- a/client/src/app/common/components/notifications/notifications.component.scss
+++ b/client/src/app/common/components/notifications/notifications.component.scss
@@ -14,6 +14,16 @@
     overflow-y: auto;
   }
 
+::ng-deep .poam-link {
+  color: var(--primary-color);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+::ng-deep .poam-link:hover {
+  text-decoration: underline;
+}
+
 .line-height-3 {
   line-height: 1.5;
 }

--- a/client/src/app/pages/import-processing/stigmanager-import/stigmanager-import.component.ts
+++ b/client/src/app/pages/import-processing/stigmanager-import/stigmanager-import.component.ts
@@ -156,7 +156,7 @@ export class STIGManagerImportComponent implements OnInit, OnDestroy {
       }),
     );
     this.initializeComponent();
-    this.selectedFindings = 'No Existing POAM';
+    this.selectedFindings = 'All';
   }
 
   private async initializeComponent() {
@@ -391,7 +391,7 @@ export class STIGManagerImportComponent implements OnInit, OnDestroy {
         (a, b) =>
           allSeverities.indexOf(a.severity) - allSeverities.indexOf(b.severity),
       );
-      this.selectedFindings = 'No Existing POAM';
+      this.selectedFindings = 'All';
       this.filterFindings();
       this.initializeChart();
       this.updateFindingsChartData(findings);

--- a/client/src/app/pages/poam-processing/poam-components/poam-assigned-grid/poam-assigned-grid.component.ts
+++ b/client/src/app/pages/poam-processing/poam-components/poam-assigned-grid/poam-assigned-grid.component.ts
@@ -35,30 +35,13 @@ export class PoamAssignedGridComponent implements OnChanges {
   }
 
   updateDataSource() {
-    let data = this.assignedData;
-
-    if (this.assignedColumns.includes('Approval Status')) {
-      data = data.filter((item) => {
-        return (
-          item.approvers &&
-          item.approvers.some(
-            (approver: any) =>
-              approver.userId === this.userId &&
-              approver.approvalStatus != 'Approved',
-          )
-        );
-      });
-    }
-
+    let data = this.assignedData;    
+    
     this.assignedDataSource = data.map((item) => ({
       poamId: item.poamId,
       adjSeverity: item.adjSeverity,
       status: item.status,
       submitter: item.submitterName,
-      approvalStatus:
-        item.approvers &&
-        item.approvers.find((approver: any) => approver.userId === this.userId)
-          ?.approvalStatus,
     }));
     this.filteredData = [...this.assignedDataSource];
     this.applyFilter();

--- a/client/src/app/pages/poam-processing/poam-details/poam-details.component.html
+++ b/client/src/app/pages/poam-processing/poam-details/poam-details.component.html
@@ -80,33 +80,44 @@
         <!-- AA Package -->
         <div class="form-group">
           <label for="aaPackage">A&A Package: </label>
-          <p-autoComplete [(ngModel)]="poam.aaPackage"
-                          [dropdown]="true"
-                          [suggestions]="filteredAAPackages"
-                          (completeMethod)="filterAAPackages($event)"
-                          [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2"
-                          placeholder="Select from the available options, modify a provided option, or provide a custom option..."
-                          name='aaPackage'
-                          id="aaPackage"
-                          styleClass="w-full">
-          </p-autoComplete>
+          <p-dropdown [(ngModel)]="poam.aaPackage"
+                      [options]="aaPackages"
+                      optionLabel="aaPackage"
+                      optionValue="aaPackage"
+                      [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2"
+                      placeholder="Select A&A Package"
+                      name='aaPackage'
+                      id="aaPackage"
+                      styleClass="w-full">
+          </p-dropdown>
         </div>
 
         <!-- Source -->
         <div class="form-group">
-          <label for="vulnerabilitySource"><i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Source Identifying Control Vulnerability: Identifies the source of the vulnerability (e.g., program review, test and evaluation program findings, IG DoD audit, and GAO audit)."></i>Source Identifying Control Vulnerability: </label>
-          <p-autoComplete class="w-full" [(ngModel)]="poam.vulnerabilitySource" [suggestions]="filteredVulnerabilitySources" (completeMethod)="searchVulnerabilitySources($event)" placeholder="Vulnerability Source..." name="vulnerabilitySource" id="vulnerabilitySource" [dropdown]="true" [style]="{'width':'100%'}" [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2"></p-autoComplete>
+          <label for="vulnerabilitySource">
+            <i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Source Identifying Control Vulnerability: Identifies the source of the vulnerability (e.g., program review, test and evaluation program findings, IG DoD audit, and GAO audit)."></i>
+            Source Identifying Control Vulnerability:
+          </label>
+          <p-dropdown [(ngModel)]="poam.vulnerabilitySource"
+                      [options]="vulnerabilitySources"
+                      placeholder="Select Vulnerability Source"
+                      name="vulnerabilitySource"
+                      id="vulnerabilitySource"
+                      [style]="{'width':'100%'}"
+                      [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2">
+          </p-dropdown>
         </div>
 
         <!-- STIG Title -->
         <div class="form-group" *ngIf="poam.vulnerabilitySource === 'STIG'">
           <label for="stigInput"><i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Source Identifying Control Vulnerability: Identifies the source of the vulnerability (e.g., program review, test and evaluation program findings, IG DoD audit, and GAO audit)."></i>STIG Title:</label>
-          <p-autoComplete [(ngModel)]="selectedStigTitle" [suggestions]="filteredStigmanSTIGs" (completeMethod)="searchStigTitles($event)" (onSelect)="onStigSelected($event)" name="stigInput" placeholder="Select STIG..." [dropdown]="true" field="title" [style]="{'width':'100%'}" [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2"></p-autoComplete>
+          <p-autoComplete [(ngModel)]="selectedStigTitle" [suggestions]="filteredStigmanSTIGs" (completeMethod)="searchStigTitles($event)" (onSelect)="onStigSelected($event)" name="stigInput" placeholder="Select STIG..." [dropdown]="true" field="title" [style]="{'width':'100%'}" [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2" readonly></p-autoComplete>
         </div>
 
         <!-- Source Identifying Control Vulnerability - ID # for Non STIGs-->
         <div class="form-group" *ngIf="poam.vulnerabilitySource !== 'STIG'">
-          <label for="vulnerabilityId"><i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Security Checks - NIST -53Rev 4 Assessment Procedure, STIG / SRG Vulnerability ID, or ACAS Plugin ID (Do not leave this field blank)."></i>Source Identifying Control Vulnerability - ID #: </label>
+          <label *ngIf="poam.vulnerabilitySource === 'Assured Compliance Assessment Solution (ACAS) Nessus Scanner'" for="vulnerabilityId"><i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Security Checks - NIST -53Rev 4 Assessment Procedure, STIG / SRG Vulnerability ID, or ACAS Plugin ID (Do not leave this field blank)."></i>Plugin ID #: </label>
+          <label *ngIf="poam.vulnerabilitySource !== 'Assured Compliance Assessment Solution (ACAS) Nessus Scanner'" for="vulnerabilityId"><i class="pi pi-info-circle mr-2" style="color: var(--text-color);" pTooltip="Security Checks - NIST -53Rev 4 Assessment Procedure, STIG / SRG Vulnerability ID, or ACAS Plugin ID (Do not leave this field blank)."></i>Source Identifying Control Vulnerability - ID #: </label>
           <input type="text" pInputText class="w-full" [(ngModel)]="poam.vulnerabilityId" [maxlength]="255" name='vulnerabilityId' id="vulnerabilityId" placeholder="Vulnerability ID..." [disabled]="(poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted') || accessLevel < 2">
         </div>
 

--- a/client/src/app/pages/poam-processing/poam-details/poam-details.component.ts
+++ b/client/src/app/pages/poam-processing/poam-details/poam-details.component.ts
@@ -331,7 +331,6 @@ export class PoamDetailsComponent implements OnInit, OnDestroy {
             lastRevisionStr: stig.lastRevisionStr,
             lastRevisionDate: stig.lastRevisionDate,
           }));
-
           if (!data || data.length === 0) {
             console.warn(
               'Unable to retrieve list of current STIGs from STIGMAN.',
@@ -953,7 +952,7 @@ ${this.pluginData.description ?? ''}`,
         (stig: any) => stig.title === event,
       );
     } else {
-      selectedStig = event;
+      selectedStig = event.value;
     }
 
     if (selectedStig) {
@@ -961,7 +960,7 @@ ${this.pluginData.description ?? ''}`,
       this.selectedStigBenchmarkId = selectedStig.benchmarkId;
       this.poam.stigTitle = (() => {
         const [version, release] =
-          selectedStig.lastRevisionStr.match(/\d+/g) || [];
+          selectedStig.lastRevisionStr?.match(/\d+/g) || [];
         const formattedRevision =
           version && release
             ? `Version ${version}, Release: ${release}`

--- a/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.html
+++ b/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.html
@@ -49,8 +49,7 @@
         </p-tabPanel>
         <p-tabPanel *ngIf="accessLevel >= 3" header="Pending Approval">
           <cpat-poam-assigned-grid [assignedData]="this.poamsPendingApproval"
-                                   [assignedColumns]="['POAM ID', 'Adjusted Severity', 'Poam Status', 'Approval Status', 'POAM']"
-                                   [userId]="this.user.userId"
+                                   [assignedColumns]="['POAM ID', 'Adjusted Severity', 'Poam Status', 'Submitter', 'POAM']"
                                    (managePoam)="managePoam($event)">
           </cpat-poam-assigned-grid>
         </p-tabPanel>

--- a/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.ts
+++ b/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.ts
@@ -30,11 +30,9 @@ import { PayloadService } from '../../../common/services/setPayload.service';
 export class PoamManageComponent implements OnInit, AfterViewInit, OnDestroy {
   advancedSeverityseverityPieChartData: any[] = [];
   advancedStatusPieChartData: any[] = [];
-  approvalColumns = ['POAM ID', 'Adjusted Severity', 'Approval Status', 'POAM'];
   private subs = new SubSink();
   public isLoggedIn = false;
   public monthlyPoamStatus: any[] = [];
-  approvalData: any[] = [];
   poams: any[] = [];
   poamsForChart: any[] = [];
   selectedPoamId: any;
@@ -150,7 +148,7 @@ export class PoamManageComponent implements OnInit, AfterViewInit, OnDestroy {
       (poam) =>
         poam.status === 'Submitted' ||
         poam.status === 'Extension Requested' ||
-        poam.status === 'Pending CAT-I Approval',
+        poam.status === 'Pending CAT-I Approval'
     );
   }
 

--- a/client/src/app/styles/components/_sidebar_slim.scss
+++ b/client/src/app/styles/components/_sidebar_slim.scss
@@ -75,6 +75,14 @@
                             display: none;
                         }
 
+                        &.active-route {
+                            background-color: color-mix(in srgb, var(--menuitem-hover-bg-color) 80%, transparent);
+                        }
+
+                        &.active-route::before {
+                            background-color: rgba(1, 1, 1, 0) !important;
+                        }
+
                         &:hover {
                             background-color: var(--menuitem-hover-bg-color);
                         }

--- a/client/src/app/styles/components/_sidebar_vertical.scss
+++ b/client/src/app/styles/components/_sidebar_vertical.scss
@@ -77,8 +77,20 @@
                 }
 
                 &.active-route {
+                    position: relative;
                     font-weight: 700;
-                    opacity: 1;
+                    background-color: color-mix(in srgb, var(--menuitem-hover-bg-color) 40%, transparent);
+                }
+                
+                &.active-route::before {
+                    content: '';
+                    position: absolute;
+                    left: 0;
+                    top: 0;
+                    bottom: 0;
+                    height: 100%;
+                    width: 4px;
+                    background-color: color-mix(in srgb, var(--primary-color) 80%, transparent) !important;
                 }
 
                 &:hover {


### PR DESCRIPTION
-Feature: POAM #'s inside of the notification popover and notification page are now clickable. If the user is not already within the collection that the POAM belongs, it will set the users collection appropriately and navigate to the POAM.
-Update STIG Manager component to filter by All as default instead of "No Existing POAM"
-Updated the POAM details component to convert the A&A Package, Vulnerability Source, and STIG Title to not allow free text entries.
-Added conditional label to "Source Identifying Control Vulnerability - ID #". When the vulnerability source is set to [ACAS] the label will not display "Plugin ID #".
-Fixed a bug that would prevent POAMs in the Pending Approval tab of the Manage POAMs->Assigned grid component from displaying properly.
-Updated styling to add an indicator for the active route. (Sidebar menu item currently selected)