### PR TITLE
fix: restrict Raw Severity modification permissions

### DIFF
--- a/client/src/app/pages/poam-processing/poam-details/poam-details.component.html
+++ b/client/src/app/pages/poam-processing/poam-details/poam-details.component.html
@@ -246,7 +246,7 @@
           <p-select [options]="severityOptions" [(ngModel)]="poam.rawSeverity" id="rawSeverity" name="rawSeverity"
             placeholder="Raw Severity..." optionLabel="label" optionValue="value" class="w-[25rem]"
             (onChange)="onAdjSeverityChange()"
-            [disabled]="poam.status !== 'Draft' && poam.status !== 'Extension Requested' && poam.status !== 'Rejected' && poam.status !== 'Submitted' && accessLevel() < 3" />
+            [disabled]="accessLevel() < 4 && (this.collectionType !== 'C-PAT' || accessLevel() < 2)" />
         </div>
 
         <!-- Adj Severity -->


### PR DESCRIPTION
fix: restrict Raw Severity modification permissions

Raw severity can only be modified if the user is assigned 'CAT-I Approver' (accessLevel 4) permissions, or if in a manual C-PAT collection if they are assigned 'Submitter' (accessLevel 2) permissions or higher.