### PR TITLE
fix: correct asset path resolution for our subpath deployment friends

### DIFF
--- a/client/src/app/common/components/vram-popup/vram-popup.component.ts
+++ b/client/src/app/common/components/vram-popup/vram-popup.component.ts
@@ -41,9 +41,9 @@ import { StepperModule } from 'primeng/stepper';
             <p-step-panel>
               <ng-template #content let-activateCallback="activateCallback">
                 <p>Ensure column options are set to default values</p>
-                <p-image src="../../../assets/vram/step1.png" alt="Image" width="600" [preview]="true" />
+                <p-image src="assets/vram/step1.png" alt="Image" width="600" [preview]="true" />
                 <br />
-                <p-image class="mt-6" src="../../../assets/vram/columnOptions.png" alt="Image" width="600" [preview]="true" />
+                <p-image class="mt-6" src="assets/vram/columnOptions.png" alt="Image" width="600" [preview]="true" />
                 <div class="flex py-6 gap-2">
                   <p-button [outlined]="true" [rounded]="true" [text]="true" [raised]="true" severity="secondary" icon="pi pi-arrow-left" (onClick)="activateCallback(1)" />
                   <p-button [outlined]="true" [rounded]="true" [text]="true" [raised]="true" icon="pi pi-arrow-right" iconPos="right" (onClick)="activateCallback(3)" />
@@ -57,7 +57,7 @@ import { StepperModule } from 'primeng/stepper';
             <p-step-panel>
               <ng-template #content let-activateCallback="activateCallback">
                 <p>Click to export. The exported file can be imported to C-PAT directly below.</p>
-                <p-image src="../../../assets/vram/step2.png" alt="Image" width="600" [preview]="true" />
+                <p-image src="assets/vram/step2.png" alt="Image" width="600" [preview]="true" />
                 <div class="flex py-6 gap-2">
                   <p-button [outlined]="true" [rounded]="true" [text]="true" [raised]="true" severity="secondary" icon="pi pi-arrow-left" (onClick)="activateCallback(2)" />
                 </div>

--- a/client/src/app/common/utils/poam-export.service.ts
+++ b/client/src/app/common/utils/poam-export.service.ts
@@ -143,7 +143,7 @@ export class PoamExportService {
   static async convertToExcel(poams: Poam[], exportingUser: any, exportCollection: any): Promise<Blob> {
     const ExcelJS = await import('exceljs');
     const workbook = new ExcelJS.default.Workbook();
-    const response = await fetch('../../../assets/eMASS_Template.xlsx');
+    const response = await fetch(`${window.location.origin}${CPAT.Env.basePath || ''}/assets/eMASS_Template.xlsx`);
     const arrayBuffer = await response.arrayBuffer();
 
     await workbook.xlsx.load(arrayBuffer, {


### PR DESCRIPTION
- Update VramPopupComponent image paths to use relative paths without ../
- Fix PoamExportService fetch URL to use window.location.origin with basePath
- Ensures assets load correctly when app is deployed at subpaths (e.g., /ab/)

Previously, assets failed to load when deployed to non-root paths due to
incorrect path resolution. Image paths using ../../../ would resolve 
outside the app's base path, and fetch calls needed explicit origin + basePath.