### PR TITLE
chore: Remove unused allowedCommonJsDependencies from angular json

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -30,7 +30,7 @@
               },
               "fonts": true
             },
-            "allowedCommonJsDependencies": ["base64-js", "js-sha256", "lodash", "chart.js", "rfdc", "exceljs", "chalk"],
+            "allowedCommonJsDependencies": ["base64-js", "exceljs"],
             "outputPath": "dist",
             "browser": "src/main.ts",
             "polyfills": ["src/polyfills.ts"],


### PR DESCRIPTION
chore: Remove unused allowedCommonJsDependencies from angular json