### PR TITLE
perf:refactor: derive payload state from authService.user$ instead of making redundant http calls

### DIFF
--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -15,7 +15,6 @@ import { Subject, of } from 'rxjs';
 import { AppComponent } from './app.component';
 import { AuthService } from './core/auth/services/auth.service';
 import { SharedService } from './common/services/shared.service';
-import { PayloadService } from './common/services/setPayload.service';
 import { InactivityService } from './core/auth/services/inactivity.service';
 
 describe('AppComponent', () => {
@@ -23,7 +22,6 @@ describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let mockAuthService: any;
   let mockSharedService: any;
-  let mockPayloadService: any;
   let mockInactivityService: any;
   let authStateSubject: Subject<{ isAuthenticatedStigman: boolean; isAuthenticatedCpat: boolean }>;
 
@@ -39,10 +37,6 @@ describe('AppComponent', () => {
       getApiConfig: vi.fn().mockReturnValue(of({ classification: 'U' }))
     };
 
-    mockPayloadService = {
-      setPayload: vi.fn().mockResolvedValue(undefined)
-    };
-
     mockInactivityService = {
       startMonitoring: vi.fn(),
       stopMonitoring: vi.fn(),
@@ -54,7 +48,6 @@ describe('AppComponent', () => {
       providers: [
         { provide: AuthService, useValue: mockAuthService },
         { provide: SharedService, useValue: mockSharedService },
-        { provide: PayloadService, useValue: mockPayloadService },
         { provide: InactivityService, useValue: mockInactivityService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -80,11 +73,11 @@ describe('AppComponent', () => {
       expect(component['authSubscription']).toBeDefined();
     });
 
-    it('should call handleAuthState when authState$ emits', async () => {
+    it('should call getApiConfig once fully authenticated', async () => {
       await component.ngOnInit();
       authStateSubject.next({ isAuthenticatedStigman: true, isAuthenticatedCpat: true });
       await Promise.resolve();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
+      expect(mockSharedService.getApiConfig).toHaveBeenCalled();
     });
   });
 
@@ -109,13 +102,6 @@ describe('AppComponent', () => {
       await Promise.resolve();
       expect(mockAuthService.handleAuthFlow).toHaveBeenCalled();
     });
-
-    it('should not call setPayload when not fully authenticated', async () => {
-      await component.ngOnInit();
-      authStateSubject.next({ isAuthenticatedStigman: false, isAuthenticatedCpat: false });
-      await Promise.resolve();
-      expect(mockPayloadService.setPayload).not.toHaveBeenCalled();
-    });
   });
 
   describe('handleAuthState — fully authenticated', () => {
@@ -135,13 +121,6 @@ describe('AppComponent', () => {
       authStateSubject.next(fullyAuthenticated);
       await Promise.resolve();
       expect(mockInactivityService.startMonitoring).not.toHaveBeenCalled();
-    });
-
-    it('should call payloadService.setPayload', async () => {
-      await component.ngOnInit();
-      authStateSubject.next(fullyAuthenticated);
-      await Promise.resolve();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
 
     it('should call sharedService.getApiConfig', async () => {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -12,7 +12,6 @@ import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Classification } from './common/models/classification.model';
-import { PayloadService } from './common/services/setPayload.service';
 import { SharedService } from './common/services/shared.service';
 import { AuthService } from './core/auth/services/auth.service';
 import { InactivityService } from './core/auth/services/inactivity.service';
@@ -27,7 +26,6 @@ import { InactivityWarningComponent } from './common/components/inactivity-warni
 export class AppComponent implements OnInit, OnDestroy {
   private readonly authService = inject(AuthService);
   private readonly sharedService = inject(SharedService);
-  private readonly payloadService = inject(PayloadService);
   private readonly inactivityService = inject(InactivityService);
 
   classification: Classification | undefined;
@@ -58,8 +56,6 @@ export class AppComponent implements OnInit, OnDestroy {
       if (this.inactivityService.shouldMonitor()) {
         this.inactivityService.startMonitoring();
       }
-
-      await this.payloadService.setPayload();
 
       this.sharedService.getApiConfig().subscribe({
         next: (apiConfig) => {

--- a/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.spec.ts
+++ b/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.spec.ts
@@ -37,7 +37,6 @@ describe('NotificationsPanelComponent', () => {
     dismissAllNotifications: ReturnType<typeof vi.fn>;
   };
   let mockPayloadService: {
-    setPayload: ReturnType<typeof vi.fn>;
     user$: BehaviorSubject<any>;
     payload$: BehaviorSubject<any>;
     accessLevel$: BehaviorSubject<number>;
@@ -74,7 +73,6 @@ describe('NotificationsPanelComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject({ userId: 1, userName: 'testuser' }),
       payload$: new BehaviorSubject({}),
       accessLevel$: new BehaviorSubject(1)
@@ -117,11 +115,6 @@ describe('NotificationsPanelComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call setPayload on PayloadService', () => {
-      component.setPayload();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to user$', () => {
       component.setPayload();
       expect(component.user).toEqual({ userId: 1, userName: 'testuser' });

--- a/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.ts
+++ b/client/src/app/common/components/notifications/notifications-popover/notifications-popover.component.ts
@@ -47,7 +47,6 @@ export class NotificationsPanelComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/common/components/notifications/notifications.component.spec.ts
+++ b/client/src/app/common/components/notifications/notifications.component.spec.ts
@@ -38,7 +38,6 @@ describe('NotificationsComponent', () => {
     deleteAllNotifications: ReturnType<typeof vi.fn>;
   };
   let mockPayloadService: {
-    setPayload: ReturnType<typeof vi.fn>;
     user$: BehaviorSubject<any>;
     payload$: BehaviorSubject<any>;
     accessLevel$: BehaviorSubject<number>;
@@ -78,7 +77,6 @@ describe('NotificationsComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject({ userId: 1, userName: 'testuser' }),
       payload$: new BehaviorSubject({}),
       accessLevel$: new BehaviorSubject(1)
@@ -134,11 +132,6 @@ describe('NotificationsComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call setPayload on PayloadService', () => {
-      component.setPayload();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to user$', () => {
       component.setPayload();
       expect(component.user).toEqual({ userId: 1, userName: 'testuser' });

--- a/client/src/app/common/components/notifications/notifications.component.ts
+++ b/client/src/app/common/components/notifications/notifications.component.ts
@@ -61,7 +61,6 @@ export class NotificationsComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/common/services/setPayload.service.spec.ts
+++ b/client/src/app/common/services/setPayload.service.spec.ts
@@ -10,14 +10,14 @@
 
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { of, throwError, firstValueFrom, filter } from 'rxjs';
+import { Subject, firstValueFrom, filter } from 'rxjs';
 import { PayloadService } from './setPayload.service';
-import { UsersService } from '../../pages/admin-processing/user-processing/users.service';
+import { AuthService } from '../../core/auth/services/auth.service';
 import { Users } from '../models/users.model';
 
 describe('PayloadService', () => {
   let service: PayloadService;
-  let mockUsersService: { getCurrentUser: ReturnType<typeof vi.fn> };
+  let userSubject: Subject<Users | null>;
 
   const mockUser: Users = {
     userId: 1,
@@ -49,12 +49,10 @@ describe('PayloadService', () => {
   };
 
   beforeEach(() => {
-    mockUsersService = {
-      getCurrentUser: vi.fn()
-    };
+    userSubject = new Subject<Users | null>();
 
     TestBed.configureTestingModule({
-      providers: [PayloadService, { provide: UsersService, useValue: mockUsersService }]
+      providers: [PayloadService, { provide: AuthService, useValue: { user$: userSubject.asObservable() } }]
     });
 
     service = TestBed.inject(PayloadService);
@@ -90,11 +88,9 @@ describe('PayloadService', () => {
     });
   });
 
-  describe('setPayload', () => {
-    it('should set user data when getCurrentUser succeeds', async () => {
-      mockUsersService.getCurrentUser.mockReturnValue(of(mockUser));
-
-      service.setPayload();
+  describe('when authService.user$ emits a valid user', () => {
+    it('should set user data', async () => {
+      userSubject.next(mockUser);
 
       const user = await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
 
@@ -103,9 +99,7 @@ describe('PayloadService', () => {
     });
 
     it('should set payload with mapped permissions', async () => {
-      mockUsersService.getCurrentUser.mockReturnValue(of(mockUser));
-
-      service.setPayload();
+      userSubject.next(mockUser);
 
       const payload = await firstValueFrom(service.payload$.pipe(filter((p) => p !== null)));
 
@@ -115,9 +109,7 @@ describe('PayloadService', () => {
     });
 
     it('should set access level based on lastCollectionAccessedId', async () => {
-      mockUsersService.getCurrentUser.mockReturnValue(of(mockUser));
-
-      service.setPayload();
+      userSubject.next(mockUser);
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const level = await firstValueFrom(service.accessLevel$);
@@ -126,9 +118,7 @@ describe('PayloadService', () => {
     });
 
     it('should set isAdmin to false for non-admin user', async () => {
-      mockUsersService.getCurrentUser.mockReturnValue(of(mockUser));
-
-      service.setPayload();
+      userSubject.next(mockUser);
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const isAdmin = await firstValueFrom(service.isAdmin$);
@@ -137,9 +127,7 @@ describe('PayloadService', () => {
     });
 
     it('should set isAdmin to true for admin user', async () => {
-      mockUsersService.getCurrentUser.mockReturnValue(of(mockAdminUser));
-
-      service.setPayload();
+      userSubject.next(mockAdminUser);
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const isAdmin = await firstValueFrom(service.isAdmin$);
@@ -147,15 +135,8 @@ describe('PayloadService', () => {
       expect(isAdmin).toBe(true);
     });
 
-    it('should handle user with no permissions', async () => {
-      const userNoPermissions: Users = {
-        ...mockUser,
-        permissions: []
-      };
-
-      mockUsersService.getCurrentUser.mockReturnValue(of(userNoPermissions));
-
-      service.setPayload();
+    it('should set accessLevel to 0 when user has no permissions', async () => {
+      userSubject.next({ ...mockUser, permissions: [] });
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const level = await firstValueFrom(service.accessLevel$);
@@ -163,30 +144,16 @@ describe('PayloadService', () => {
       expect(level).toBe(0);
     });
 
-    it('should handle user with undefined permissions', async () => {
-      const userUndefinedPermissions: Users = {
-        ...mockUser,
-        permissions: undefined as any
-      };
-
-      mockUsersService.getCurrentUser.mockReturnValue(of(userUndefinedPermissions));
-
-      service.setPayload();
+    it('should set payload.collections to undefined when permissions are undefined', async () => {
+      userSubject.next({ ...mockUser, permissions: undefined as any });
 
       const payload = await firstValueFrom(service.payload$.pipe(filter((p) => p !== null)));
 
       expect(payload.collections).toBeUndefined();
     });
 
-    it('should set accessLevel to 0 when lastCollectionAccessedId not found in permissions', async () => {
-      const userDifferentCollection: Users = {
-        ...mockUser,
-        lastCollectionAccessedId: 999
-      };
-
-      mockUsersService.getCurrentUser.mockReturnValue(of(userDifferentCollection));
-
-      service.setPayload();
+    it('should set accessLevel to 0 when lastCollectionAccessedId not in permissions', async () => {
+      userSubject.next({ ...mockUser, lastCollectionAccessedId: 999 });
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const level = await firstValueFrom(service.accessLevel$);
@@ -194,56 +161,42 @@ describe('PayloadService', () => {
       expect(level).toBe(0);
     });
 
-    it('should handle error when getCurrentUser fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      mockUsersService.getCurrentUser.mockReturnValue(throwError(() => new Error('API Error')));
-
-      service.setPayload();
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(consoleSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
-      consoleSpy.mockRestore();
-    });
-
-    it('should handle response with no userId', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      mockUsersService.getCurrentUser.mockReturnValue(of({} as Users));
-
-      service.setPayload();
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(consoleSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
-      consoleSpy.mockRestore();
-    });
-
-    it('should handle null response', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      mockUsersService.getCurrentUser.mockReturnValue(of(null));
-
-      service.setPayload();
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(consoleSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
-      consoleSpy.mockRestore();
-    });
-
-    it('should handle user with isAdmin undefined', async () => {
-      const userUndefinedAdmin: Users = {
-        ...mockUser,
-        isAdmin: undefined as any
-      };
-
-      mockUsersService.getCurrentUser.mockReturnValue(of(userUndefinedAdmin));
-
-      service.setPayload();
+    it('should set isAdmin to false when isAdmin is undefined', async () => {
+      userSubject.next({ ...mockUser, isAdmin: undefined as any });
 
       await firstValueFrom(service.user$.pipe(filter((u) => u !== null)));
       const isAdmin = await firstValueFrom(service.isAdmin$);
 
       expect(isAdmin).toBe(false);
+    });
+  });
+
+  describe('when authService.user$ emits a value that should be filtered', () => {
+    it('should not update subjects when user has no userId', async () => {
+      userSubject.next({} as Users);
+
+      const user = await firstValueFrom(service.user$);
+
+      expect(user).toBeNull();
+    });
+
+    it('should not update subjects when null is emitted', async () => {
+      userSubject.next(null);
+
+      const user = await firstValueFrom(service.user$);
+
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('when authService.user$ errors', () => {
+    it('should log the error', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      userSubject.error(new Error('Auth error'));
+
+      expect(consoleSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/client/src/app/common/services/setPayload.service.ts
+++ b/client/src/app/common/services/setPayload.service.ts
@@ -9,10 +9,10 @@
 */
 
 import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, map } from 'rxjs';
+import { BehaviorSubject, filter } from 'rxjs';
 import { Permission } from '../../common/models/permission.model';
 import { Users } from '../../common/models/users.model';
-import { UsersService } from '../../pages/admin-processing/user-processing/users.service';
+import { AuthService } from '../../core/auth/services/auth.service';
 
 interface Payload extends Users {
   collections: Permission[];
@@ -22,7 +22,7 @@ interface Payload extends Users {
   providedIn: 'root'
 })
 export class PayloadService {
-  private readonly userService = inject(UsersService);
+  private readonly authService = inject(AuthService);
 
   private readonly userSubject = new BehaviorSubject<any>(null);
   private readonly payloadSubject = new BehaviorSubject<any>(null);
@@ -34,51 +34,37 @@ export class PayloadService {
   accessLevel$ = this.accessLevelSubject.asObservable();
   isAdmin$ = this.isAdminSubject.asObservable();
 
-  setPayload() {
-    this.userService
-      .getCurrentUser()
-      .pipe(
-        map((response: Users) => {
-          if (response?.userId) {
-            const user = response;
-            const mappedPermissions: Permission[] = user.permissions?.map((permission) => ({
-              collectionId: permission.collectionId,
-              accessLevel: permission.accessLevel
-            }));
+  constructor() {
+    this.authService.user$.pipe(filter((user): user is Users => !!user?.userId)).subscribe({
+      next: (user: Users) => {
+        const mappedPermissions: Permission[] = user.permissions?.map((permission) => ({
+          collectionId: permission.collectionId,
+          accessLevel: permission.accessLevel
+        }));
 
-            const payload: Payload = {
-              ...user,
-              collections: mappedPermissions
-            };
+        const payload: Payload = {
+          ...user,
+          collections: mappedPermissions
+        };
 
-            let accessLevel = 0;
+        let accessLevel = 0;
 
-            if (mappedPermissions?.length > 0) {
-              const selectedPermissions = payload.collections.find((x) => x.collectionId === payload.lastCollectionAccessedId);
+        if (mappedPermissions?.length > 0) {
+          const selectedPermissions = payload.collections.find((x) => x.collectionId === payload.lastCollectionAccessedId);
 
-              if (selectedPermissions) {
-                accessLevel = selectedPermissions.accessLevel;
-              }
-            }
-
-            const isAdmin = user.isAdmin || false;
-
-            return { user, payload, accessLevel, isAdmin };
+          if (selectedPermissions) {
+            accessLevel = selectedPermissions.accessLevel;
           }
-
-          throw new Error('User ID is not available');
-        })
-      )
-      .subscribe({
-        next: ({ user, payload, accessLevel, isAdmin }) => {
-          this.userSubject.next(user);
-          this.payloadSubject.next(payload);
-          this.accessLevelSubject.next(accessLevel);
-          this.isAdminSubject.next(isAdmin);
-        },
-        error: (error) => {
-          console.error('An error occurred:', error);
         }
-      });
+
+        this.userSubject.next(user);
+        this.payloadSubject.next(payload);
+        this.accessLevelSubject.next(accessLevel);
+        this.isAdminSubject.next(user.isAdmin || false);
+      },
+      error: (error) => {
+        console.error('An error occurred:', error);
+      }
+    });
   }
 }

--- a/client/src/app/layout/components/app.navigation.component.spec.ts
+++ b/client/src/app/layout/components/app.navigation.component.spec.ts
@@ -64,8 +64,7 @@ describe('AppNavigationComponent', () => {
     mockPayloadService = {
       user$: payloadUserSubject.asObservable(),
       payload$: new BehaviorSubject<any>(null).asObservable(),
-      accessLevel$: new BehaviorSubject<any>(0).asObservable(),
-      setPayload: vi.fn()
+      accessLevel$: new BehaviorSubject<any>(0).asObservable()
     };
 
     mockUserService = {

--- a/client/src/app/layout/components/app.navigation.component.ts
+++ b/client/src/app/layout/components/app.navigation.component.ts
@@ -140,7 +140,6 @@ export class AppNavigationComponent implements OnInit, OnDestroy {
 
   async initializeUser() {
     try {
-      this.setPayloadService.setPayload();
       this.payloadSubscription.push(
         this.setPayloadService.user$.subscribe((user) => {
           this.user = user;

--- a/client/src/app/layout/components/app.topbar.component.spec.ts
+++ b/client/src/app/layout/components/app.topbar.component.spec.ts
@@ -59,8 +59,7 @@ describe('AppTopBarComponent', () => {
     mockPayloadService = {
       user$: userSubject.asObservable(),
       payload$: new BehaviorSubject(null).asObservable(),
-      accessLevel$: new BehaviorSubject(0).asObservable(),
-      setPayload: vi.fn()
+      accessLevel$: new BehaviorSubject(0).asObservable()
     };
 
     mockUserService = {

--- a/client/src/app/pages/admin-processing/asset-delta/asset-delta.component.spec.ts
+++ b/client/src/app/pages/admin-processing/asset-delta/asset-delta.component.spec.ts
@@ -103,8 +103,7 @@ describe('AssetDeltaComponent', () => {
     };
 
     mockPayloadService = {
-      user$: of(mockUser),
-      setPayload: vi.fn()
+      user$: of(mockUser)
     };
 
     mockMessageService = createMockMessageService();

--- a/client/src/app/pages/admin-processing/collection-processing/collection-processing.component.spec.ts
+++ b/client/src/app/pages/admin-processing/collection-processing/collection-processing.component.spec.ts
@@ -92,7 +92,6 @@ describe('CollectionProcessingComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -263,12 +262,6 @@ describe('CollectionProcessingComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call setPayloadService.setPayload', () => {
-      component.setPayload();
-
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should assign user from user$ subscription', () => {
       component.setPayload();
 

--- a/client/src/app/pages/admin-processing/collection-processing/collection-processing.component.ts
+++ b/client/src/app/pages/admin-processing/collection-processing/collection-processing.component.ts
@@ -144,7 +144,6 @@ export class CollectionProcessingComponent implements OnInit, OnDestroy {
   }
 
   setPayload() {
-    this.setPayloadService.setPayload();
     this.subs.sink = this.setPayloadService.user$.subscribe((user) => {
       this.user = user;
     });

--- a/client/src/app/pages/admin-processing/user-processing/user-processing.component.spec.ts
+++ b/client/src/app/pages/admin-processing/user-processing/user-processing.component.spec.ts
@@ -118,7 +118,6 @@ describe('UserProcessingComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -240,12 +239,6 @@ describe('UserProcessingComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call setPayloadService.setPayload', async () => {
-      await component.setPayload();
-
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should set user from user$ subscription', async () => {
       await component.setPayload();
 

--- a/client/src/app/pages/admin-processing/user-processing/user-processing.component.ts
+++ b/client/src/app/pages/admin-processing/user-processing/user-processing.component.ts
@@ -85,7 +85,6 @@ export class UserProcessingComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/admin-processing/user-processing/user/user.component.spec.ts
+++ b/client/src/app/pages/admin-processing/user-processing/user/user.component.spec.ts
@@ -105,8 +105,7 @@ describe('UserComponent', () => {
     mockMessageService = createMockMessageService();
 
     mockPayloadService = {
-      user$: of(null),
-      setPayload: vi.fn()
+      user$: of(null)
     };
 
     await TestBed.configureTestingModule({

--- a/client/src/app/pages/asset-processing/asset-processing.component.spec.ts
+++ b/client/src/app/pages/asset-processing/asset-processing.component.spec.ts
@@ -74,7 +74,6 @@ describe('AssetProcessingComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -195,11 +194,6 @@ describe('AssetProcessingComponent', () => {
       await component.ngOnInit();
       expect(component.cols).toBeDefined();
       expect(component.cols.length).toBe(5);
-    });
-
-    it('should call setPayloadService.setPayload', async () => {
-      await component.ngOnInit();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/pages/asset-processing/asset-processing.component.ts
+++ b/client/src/app/pages/asset-processing/asset-processing.component.ts
@@ -173,7 +173,6 @@ export class AssetProcessingComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/home/home.component.spec.ts
+++ b/client/src/app/pages/home/home.component.spec.ts
@@ -10,6 +10,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HomeComponent } from './home.component';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;

--- a/client/src/app/pages/import-processing/tenable-import/components/tenableFilters/tenableFilters.component.spec.ts
+++ b/client/src/app/pages/import-processing/tenable-import/components/tenableFilters/tenableFilters.component.spec.ts
@@ -56,7 +56,6 @@ describe('TenableFiltersComponent', () => {
     mockMessageService = createMockMessageService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       accessLevel$: accessLevelSubject.asObservable(),
       user$: userSubject.asObservable()
     };
@@ -117,11 +116,6 @@ describe('TenableFiltersComponent', () => {
   });
 
   describe('ngOnInit', () => {
-    it('should call setPayload', () => {
-      component.ngOnInit();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to accessLevel$ and update signal', () => {
       component.ngOnInit();
       expect(component.accessLevel()).toBe(2);

--- a/client/src/app/pages/import-processing/tenable-import/components/tenableFilters/tenableFilters.component.ts
+++ b/client/src/app/pages/import-processing/tenable-import/components/tenableFilters/tenableFilters.component.ts
@@ -64,8 +64,6 @@ export class TenableFiltersComponent implements OnInit, OnDestroy {
   private readonly subscriptions = new Subscription();
 
   ngOnInit() {
-    this.setPayloadService.setPayload();
-
     this.subscriptions.add(
       this.setPayloadService.accessLevel$.subscribe(async (level) => {
         this.accessLevel.set(level);

--- a/client/src/app/pages/import-processing/tenable-import/components/tenableVulnerabilities/tenableVulnerabilities.component.spec.ts
+++ b/client/src/app/pages/import-processing/tenable-import/components/tenableVulnerabilities/tenableVulnerabilities.component.spec.ts
@@ -78,7 +78,6 @@ describe('TenableVulnerabilitiesComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject<any>(null).asObservable(),
       accessLevel$: new BehaviorSubject<number>(2).asObservable()
     };

--- a/client/src/app/pages/import-processing/tenable-import/components/tenableVulnerabilities/tenableVulnerabilities.component.ts
+++ b/client/src/app/pages/import-processing/tenable-import/components/tenableVulnerabilities/tenableVulnerabilities.component.ts
@@ -945,8 +945,6 @@ export class TenableVulnerabilitiesComponent implements OnInit, OnDestroy {
       this.tempFilters = this.initializeTempFilters();
     }
 
-    this.setPayloadService.setPayload();
-
     this.subscriptions.add(
       this.sharedService.selectedCollection.subscribe((collectionId) => {
         this.selectedCollection = collectionId;

--- a/client/src/app/pages/label-processing/label-processing.component.spec.ts
+++ b/client/src/app/pages/label-processing/label-processing.component.spec.ts
@@ -62,7 +62,6 @@ describe('LabelProcessingComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -137,11 +136,6 @@ describe('LabelProcessingComponent', () => {
       component.ngOnInit();
       selectedCollectionSubject.next(5);
       expect(component.selectedCollection).toBe(5);
-    });
-
-    it('should call setPayloadService.setPayload', () => {
-      component.ngOnInit();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/pages/label-processing/label-processing.component.ts
+++ b/client/src/app/pages/label-processing/label-processing.component.ts
@@ -84,7 +84,6 @@ export class LabelProcessingComponent implements OnInit, OnDestroy {
   }
 
   setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/label-processing/label/label.component.spec.ts
+++ b/client/src/app/pages/label-processing/label/label.component.spec.ts
@@ -61,7 +61,6 @@ describe('LabelComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       accessLevel$: accessLevelSubject.asObservable()
     };
 

--- a/client/src/app/pages/poam-processing/poam-approve/poam-approve.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-approve/poam-approve.component.spec.ts
@@ -70,7 +70,6 @@ describe('PoamApproveComponent', () => {
     mockMessageService = createMockMessageService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject(mockUser),
       payload$: new BehaviorSubject({ lastCollectionAccessedId: 1 }),
       accessLevel$: accessLevelSubject
@@ -147,11 +146,6 @@ describe('PoamApproveComponent', () => {
       fixture.detectChanges();
       selectedCollectionSubject.next(5);
       expect(component.selectedCollection).toBe(5);
-    });
-
-    it('should call setPayload on init', () => {
-      fixture.detectChanges();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/pages/poam-processing/poam-approve/poam-approve.component.ts
+++ b/client/src/app/pages/poam-processing/poam-approve/poam-approve.component.ts
@@ -99,7 +99,6 @@ export class PoamApproveComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/poam-processing/poam-details/components/poam-attachments/poam-attachments.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-details/components/poam-attachments/poam-attachments.component.spec.ts
@@ -44,7 +44,6 @@ describe('PoamAttachmentsComponent', () => {
     };
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       accessLevel$: new BehaviorSubject(2)
     };
 
@@ -104,11 +103,6 @@ describe('PoamAttachmentsComponent', () => {
   });
 
   describe('ngOnInit', () => {
-    it('should call setPayload on PayloadService', async () => {
-      await component.ngOnInit();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to accessLevel$ and set accessLevel', async () => {
       await component.ngOnInit();
       expect(component['accessLevel']).toBe(2);

--- a/client/src/app/pages/poam-processing/poam-details/components/poam-attachments/poam-attachments.component.ts
+++ b/client/src/app/pages/poam-processing/poam-details/components/poam-attachments/poam-attachments.component.ts
@@ -93,7 +93,6 @@ export class PoamAttachmentsComponent implements OnInit, OnDestroy {
   ];
 
   async ngOnInit() {
-    this.setPayloadService.setPayload();
     this.accessLevelSubscription = this.setPayloadService.accessLevel$.subscribe((level) => {
       this.accessLevel = level;
 

--- a/client/src/app/pages/poam-processing/poam-details/poam-details.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-details/poam-details.component.spec.ts
@@ -85,7 +85,6 @@ describe('PoamDetailsComponent', () => {
     mockConfirmationService = createMockConfirmationService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -399,11 +398,6 @@ describe('PoamDetailsComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call setPayloadService.setPayload', () => {
-      component.setPayload();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to user$ and set user', () => {
       component.setPayload();
       expect(component.user).toEqual(mockUser);

--- a/client/src/app/pages/poam-processing/poam-details/poam-details.component.ts
+++ b/client/src/app/pages/poam-processing/poam-details/poam-details.component.ts
@@ -295,7 +295,6 @@ export class PoamDetailsComponent implements OnInit, OnDestroy {
   }
 
   setPayload() {
-    this.setPayloadService.setPayload();
     this.subs.add(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/poam-processing/poam-extend/poam-extend.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-extend/poam-extend.component.spec.ts
@@ -114,7 +114,6 @@ describe('PoamExtendComponent', () => {
     mockConfirmationService = createMockConfirmationService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject(mockUser),
       payload$: new BehaviorSubject({ lastCollectionAccessedId: 1 }),
       accessLevel$: accessLevelSubject
@@ -260,11 +259,6 @@ describe('PoamExtendComponent', () => {
       fixture.detectChanges();
       selectedCollectionSubject.next(5);
       expect(component.selectedCollection).toBe(5);
-    });
-
-    it('should call setPayload', () => {
-      fixture.detectChanges();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/pages/poam-processing/poam-extend/poam-extend.component.ts
+++ b/client/src/app/pages/poam-processing/poam-extend/poam-extend.component.ts
@@ -171,7 +171,6 @@ export class PoamExtendComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/app/pages/poam-processing/poam-grid/poam-grid.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-grid/poam-grid.component.spec.ts
@@ -97,7 +97,6 @@ describe('PoamGridComponent', () => {
     mockDialogService = createMockDialogService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject({ userId: 1, userName: 'testuser' })
     };
 
@@ -210,11 +209,6 @@ describe('PoamGridComponent', () => {
       await component.setPayload();
       selectedCollectionSubject.next(2);
       expect(component.selectedCollectionId()).toBe(2);
-    });
-
-    it('should call payloadService.setPayload', async () => {
-      await component.setPayload();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
 
     it('should subscribe to user$', async () => {

--- a/client/src/app/pages/poam-processing/poam-grid/poam-grid.component.ts
+++ b/client/src/app/pages/poam-processing/poam-grid/poam-grid.component.ts
@@ -327,7 +327,6 @@ export class PoamGridComponent implements OnInit, OnDestroy {
       })
     );
 
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user.set(user);

--- a/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.spec.ts
@@ -91,7 +91,6 @@ describe('PoamManageComponent', () => {
     mockMessageService = createMockMessageService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: new BehaviorSubject({
         userId: 200,
         userName: 'testuser',
@@ -230,7 +229,6 @@ describe('PoamManageComponent', () => {
       await component.ngOnInit();
 
       expect(component.selectedCollectionId()).toBe(1);
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
     });
 
     it('should update selectedCollectionId when collection changes', async () => {

--- a/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.ts
+++ b/client/src/app/pages/poam-processing/poam-manage/poam-manage.component.ts
@@ -99,8 +99,6 @@ export class PoamManageComponent implements OnInit, OnDestroy {
   }
 
   private async setPayload() {
-    this.setPayloadService.setPayload();
-
     this.subs.sink = combineLatest([this.setPayloadService.user$, this.setPayloadService.payload$, this.setPayloadService.accessLevel$])
       .pipe(
         filter(([user, payload, level]) => !!user && !!payload && level > 0),

--- a/client/src/app/pages/poam-processing/poams.component.spec.ts
+++ b/client/src/app/pages/poam-processing/poams.component.spec.ts
@@ -43,7 +43,6 @@ describe('PoamsComponent', () => {
     mockMessageService = createMockMessageService();
 
     mockPayloadService = {
-      setPayload: vi.fn(),
       user$: userSubject.asObservable(),
       payload$: payloadSubject.asObservable(),
       accessLevel$: accessLevelSubject.asObservable()
@@ -87,11 +86,6 @@ describe('PoamsComponent', () => {
   });
 
   describe('setPayload', () => {
-    it('should call payloadService.setPayload', async () => {
-      await component.setPayload();
-      expect(mockPayloadService.setPayload).toHaveBeenCalled();
-    });
-
     it('should subscribe to user$', async () => {
       await component.setPayload();
       expect(component.user).toEqual({ userId: 1, userName: 'testuser', lastCollectionAccessedId: 1 });

--- a/client/src/app/pages/poam-processing/poams.component.ts
+++ b/client/src/app/pages/poam-processing/poams.component.ts
@@ -46,7 +46,6 @@ export class PoamsComponent implements OnInit, OnDestroy {
   }
 
   async setPayload() {
-    this.setPayloadService.setPayload();
     this.payloadSubscription.push(
       this.setPayloadService.user$.subscribe((user) => {
         this.user = user;

--- a/client/src/testing/mocks/service-mocks.ts
+++ b/client/src/testing/mocks/service-mocks.ts
@@ -16,8 +16,7 @@ import { vi } from 'vitest';
  */
 export function createMockPayloadService() {
   return {
-    user$: new Subject(),
-    setPayload: vi.fn()
+    user$: new Subject()
   };
 }
 


### PR DESCRIPTION
perf:refactor: derive payload state from authService.user$ instead of making redundant http calls